### PR TITLE
switch to D2L_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
@@ -21,5 +23,5 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: false


### PR DESCRIPTION
The security team will soon be enforcing that branch protection with code reviews is enabled for all repos. For semantic-release, that means that the normal `GITHUB_TOKEN` doesn't have permission to commit the version update in `package.json` to `master`.

To get around this, the `D2L_GITHUB_TOKEN` can be used as long as the `brightspace-bot` user has Admin access to the repo. We set `persist-credentials` to `false` to make sure that the standard `GITHUB_TOKEN` environment variable doesn't get configured.
