### PR TITLE
fix: Switching done and cancel listeners

### DIFF
--- a/components/rule-picker-dialog.js
+++ b/components/rule-picker-dialog.js
@@ -64,8 +64,8 @@ class RulePickerDialog extends LocalizeElement(RtlMixin(LitElement)) {
 					>
 				</rule-picker>
 
-				<d2l-button id="dialog-cancel-button" @click="${this._dialogCancelPressed}" slot="footer" primary data-dialog-action="done">Done</d2l-button>
-				<d2l-button id="dialog-done-button" @click="${this._dialogDonePressed}" slot="footer" data-dialog-action>Cancel</d2l-button>
+				<d2l-button @click="${this._dialogDonePressed}" slot="footer" primary data-dialog-action="done">Done</d2l-button>
+				<d2l-button @click="${this._dialogCancelPressed}" slot="footer" data-dialog-action>Cancel</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/test/rule-picker-dialog.test.js
+++ b/test/rule-picker-dialog.test.js
@@ -43,7 +43,7 @@ describe('RulePickerDialog', () => {
 
 			const listener = oneEvent(el, 'rule-conditions-changed');
 
-			const doneButton = el.shadowRoot.querySelector('#dialog-done-button');
+			const doneButton = el.shadowRoot.querySelector('d2l-button[primary]');
 			doneButton.click();
 			const result = await verifyEventTimeout(listener, 'no event fired');
 			await el.updateComplete;


### PR DESCRIPTION
## Context
- The Done and Cancel buttons had listeners reversed
- This fix allows the `rule-conditions-changed` event to fire correctly
- Removed the `id` attributes on the buttons, which were only being used for test targetting. Using attribute targetting instead

Separately, I think these components might be a bit too data-driven to stay full UI components. I'm considering migrating them to be foundation components, but for now this should unblock work.

## Quality
- Run `npm start` and observe the events in the demo